### PR TITLE
Improve color contrast

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -1,12 +1,12 @@
 $background-color: #f2f2f2;
-$text-color: #444444;
-$text-color-secondary: #666666;
-$link-hover-color: #888888;
+$text-color: #222222;
+$text-color-secondary: #555555;
+$link-hover-color: #666666;
 
 $background-color-dark: #0d0d0d;
-$text-color-dark: #bbbbbb;
-$text-color-secondary-dark: #999999;
-$link-hover-color-dark: #777777;
+$text-color-dark: #dddddd;
+$text-color-secondary-dark: #aaaaaa;
+$link-hover-color-dark: #999999;
 
 $body-fonts: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 
@@ -21,7 +21,7 @@ $body-fonts: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubun
     :root {
         --background-color: #{$background-color-dark};
         --text-color: #{$text-color-dark};
-        --text-color-secondary: #{$text-color-secondary};
+        --text-color-secondary: #{$text-color-secondary-dark};
         --link-hover-color: #{$link-hover-color-dark};
     }
 }


### PR DESCRIPTION
Also, fix dark mode secondary text color. It had been set to
`$text-color-secondary` instead of
`$text-color-secondary-dark`.