### PR TITLE
Revert "Use scss nested selectors for code"

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -110,12 +110,12 @@ div.language-java::before {
 
 code {
     font-family: $code-fonts;
+}
 
-    .language-plaintext {
-        background-color: var(--code-bg);
-        border-radius: 4px;
-        border-width: 1px;
-        border-style: solid;
-        border-color: var(--code-border);
-    }
+code.language-plaintext {
+    background-color: var(--code-bg);
+    border-radius: 4px;
+    border-width: 1px;
+    border-style: solid;
+    border-color: var(--code-border);
 }


### PR DESCRIPTION
This attempted compactification / cleanup had unintended consequences.
Before the commit, the selector was `code.language-plaintext`.
After, the selector compiled to `code .language-plaintext`, selecting the *child* of a `code` element.

This reverts commit d8c669d9cf2c66f88387ca02ae127fda3e2f2e20.