### PR TITLE
Hotfix: revert server side katex

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,17 +17,6 @@ defaults:
       layout: "default"
 
 markdown: kramdown
-kramdown:
-  math_engine: katex
-  math_engine_opts: {
-    globalGroup: true, 
-    macros: {
-      "\\zero": "\\text{🥚}", 
-      "\\one": "\\text{🦆}", 
-      "\\idk": "?",
-      "\\inv#1": "#1^{\\tiny -1}}"
-    }
-  }
 
 highlighter: rouge
 

--- a/_includes/math.html
+++ b/_includes/math.html
@@ -2,3 +2,22 @@
     integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" 
     crossorigin="anonymous" 
     media="all">
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js"
+    integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4"
+    crossorigin="anonymous"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js"
+    integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa" crossorigin="anonymous"
+    onload="defineDelimiters()"></script>
+<script defer>
+    function defineDelimiters() {
+        window.renderMathInElement(document.documentElement, {
+            delimiters: [
+                { left: "$$", right: "$$", display: true },
+                { left: "$", right: "$", display: false },
+                { left: "\\(", right: "\\)", display: false },
+                { left: "\\[", right: "\\]", display: true }
+            ],
+            strict: "ignore"
+        })
+    }
+</script>


### PR DESCRIPTION
After hours of fighting GH Pages and KaTeX to make math parsing happen server-side, it doesn't show up properly on the actual production site.
I don't know what went wrong, but I'm going to abandon that project for now.
I still have all the commits and such so I can go back and try again when I have my sanity.