### PR TITLE
Unexclude CNAME in jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,6 @@ sass:
 
 exclude:
   - README.md
-  - CNAME
   - Makefile
   - .sass-cache/
   - .jekyll-cache/


### PR DESCRIPTION
Otherwise *every time I merge to master*, the `jsteele.cc` domain disappears