### PR TITLE
Defer loading KaTeX css

### DIFF
--- a/_includes/math.html
+++ b/_includes/math.html
@@ -1,4 +1,16 @@
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"
-    integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" 
+{% assign katex_css_link = "https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css" %}
+{% assign katex_css_integrity = "sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" %}
+
+<link rel="preload" href="{{ katex_css_link }}" 
+    integrity="{{ katex_css_integrity }}"
+    crossorigin="anonymous"
+    media="all"
+    as="style"
+    onload="this.onload=null;this.rel='stylesheet'">
+
+<noscript>
+    <link rel="stylesheet" href="{{ katex_css_link }}"
+    integrity="{{ katex_css_integrity }}" 
     crossorigin="anonymous" 
     media="all">
+</noscript>


### PR DESCRIPTION
Use `<link rel="preload" ...>` to defer loading the KaTeX css so that the page loads faster.